### PR TITLE
Added insecure TLS negotiation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ Based on work from Scott Sutherland (@\_nullbind), Antti Rantasaari, Eric Gruber
 
 ## Install
 
-Use the executables in the releases section. If you want to build it yourself, make sure that your go environment is setup according to the <a href="https://golang.org/doc/code.html">Go setup doc</a>. The goddi package also uses the below package.
+`go install github.com/swarley7/goddi`
 
-    go get gopkg.in/ldap.v2
+Or, 
+
+```
+git clone https://github.com/swarley7/goddi.git
+cd goddi
+go install
+```    
 
 ### Windows
 

--- a/ddi/conn.go
+++ b/ddi/conn.go
@@ -24,6 +24,7 @@ type LdapInfo struct {
 	Unsafe           bool
 	StartTLS         bool
 	ForceInsecureTLS bool
+	MntPoint         string
 }
 
 func dial(li *LdapInfo) {

--- a/ddi/conn.go
+++ b/ddi/conn.go
@@ -12,17 +12,18 @@ import (
 
 // LdapInfo contains connection info
 type LdapInfo struct {
-	LdapServer  string
-	LdapIP      string
-	LdapPort    uint16
-	LdapTLSPort uint16
-	User        string
-	Usergpp     string
-	Pass        string
-	Domain      string
-	Conn        *ldap.Conn
-	Unsafe      bool
-	StartTLS    bool
+	LdapServer       string
+	LdapIP           string
+	LdapPort         uint16
+	LdapTLSPort      uint16
+	User             string
+	Usergpp          string
+	Pass             string
+	Domain           string
+	Conn             *ldap.Conn
+	Unsafe           bool
+	StartTLS         bool
+	ForceInsecureTLS bool
 }
 
 func dial(li *LdapInfo) {
@@ -48,7 +49,7 @@ func dial(li *LdapInfo) {
 
 		fmt.Printf("[i] PLAINTEXT LDAP connection to '%s' (%s) successful...\n[i] Upgrade to StartTLS connection...\n", li.LdapServer, li.LdapIP)
 
-		err = conn.StartTLS(&tls.Config{ServerName: li.LdapServer})
+		err = conn.StartTLS(&tls.Config{ServerName: li.LdapServer, InsecureSkipVerify: li.ForceInsecureTLS})
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -58,7 +59,7 @@ func dial(li *LdapInfo) {
 	} else {
 
 		fmt.Printf("[i] Begin LDAP TLS connection to '%s' (%s)...\n", li.LdapServer, li.LdapIP)
-		config := &tls.Config{ServerName: li.LdapServer}
+		config := &tls.Config{ServerName: li.LdapServer, InsecureSkipVerify: li.ForceInsecureTLS}
 		conn, err := ldap.DialTLS("tcp", fmt.Sprintf("%s:%d", li.LdapServer, li.LdapTLSPort), config)
 		if err != nil {
 			log.Fatal(err)

--- a/ddi/gpp_unix.go
+++ b/ddi/gpp_unix.go
@@ -100,7 +100,7 @@ func existMount(mntpoint string) {
 	// if /mnt/goddi does not exist, mkdir the directory
 	if _, err := os.Stat(mntpoint); os.IsNotExist(err) {
 		os.Mkdir(mntpoint, os.ModePerm)
-		fmt.Println("[i] /mnt/goddi mount point created...\n")
+		fmt.Printf("[i] %s mount point created...\n", mntpoint)
 	}
 }
 
@@ -108,7 +108,7 @@ func existMount(mntpoint string) {
 func checkMount(mntpoint string) {
 
 	if len(getSubDirs(mntpoint)) != 0 {
-		fmt.Printf("[i] /mnt/goddi mounted, unmounting now...\n")
+		fmt.Printf("[i] %s mounted, unmounting now...\n", mntpoint)
 		_, err := removeUnix(mntpoint)
 		if err != nil {
 			log.Fatal(err)

--- a/ddi/gpp_unix.go
+++ b/ddi/gpp_unix.go
@@ -15,7 +15,7 @@ import (
 // GetGPP grabs all GPP passwords
 // Reference: Scott Sutherland (@_nullbind), Chris Campbell (@obscuresec)
 // https://github.com/PowerShellMafia/PowerSploit/blob/master/Exfiltration/Get-GPPPassword.ps1
-func GetGPP(conn *ldap.Conn, baseDN string, dc string, user string, pass string) {
+func GetGPP(conn *ldap.Conn, baseDN string, dc string, user string, pass string, mntpoint string) {
 
 	fmt.Printf("[i] GPP enumeration starting. This can take a bit...\n")
 
@@ -43,7 +43,6 @@ func GetGPP(conn *ldap.Conn, baseDN string, dc string, user string, pass string)
 
 	csv := [][]string{}
 	csv = append(csv, attributes)
-	mntpoint := "/mnt/goddi/"
 
 	existMount(mntpoint)
 	checkMount(mntpoint)

--- a/ddi/gpp_win.go
+++ b/ddi/gpp_win.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package goddi
@@ -14,7 +15,7 @@ import (
 // GetGPP grabs all GPP passwords
 // Reference: Scott Sutherland (@_nullbind), Chris Campbell (@obscuresec)
 // https://github.com/PowerShellMafia/PowerSploit/blob/master/Exfiltration/Get-GPPPassword.ps1
-func GetGPP(conn *ldap.Conn, domain string, dc string, user string, pass string) {
+func GetGPP(conn *ldap.Conn, domain string, dc string, user string, pass string, _ string) { //Mountpoint not needed here cos windows, lol
 
 	fmt.Printf("[i] GPP enumeration starting. This can take a bit...\n")
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/swarley7/goddi
+
+go 1.18
+
+require gopkg.in/ldap.v2 v2.5.1
+
+require gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d h1:TxyelI5cVkbREznMhfzycHdkp5cLA7DpE+GKjSslYhM=
+gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
+gopkg.in/ldap.v2 v2.5.1 h1:wiu0okdNfjlBzg6UWvd1Hn8Y+Ux17/u/4nlk4CQr6tU=
+gopkg.in/ldap.v2 v2.5.1/go.mod h1:oI0cpe/D7HRtBQl8aTg+ZmzFUAvu4lsv3eLXMLGFxWk=

--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ import (
 )
 
 func main() {
-
-	ldapServer := flag.String("dc", "", "DC to connect to, use IP or full hostname ex. -dc=\"dc.test.local\"")
+	ldapHostname := flag.String("dc", "", "Hostname of DC to connect to. ex. -dc=\"dc.test.local\"")
+	ldapIP := flag.String("dc-ip", "", "Optional: IP address of DC to connect to (useful if proxyfying without DNS magic)")
 	domain := flag.String("domain", "", "domain ex. -domain=\"test.local\"")
 	user := flag.String("username", "", "username to connect with ex. -username=\"testuser\"")
 	pass := flag.String("password", "", "password to connect with ex. -password=\"testpass!\"")
@@ -44,20 +44,20 @@ func main() {
 		*mntpoint = *mntpoint + "/"
 	}
 
-	if len(*ldapServer) == 0 || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
+	if len(*ldapHostname) == 0 || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
 		flag.PrintDefaults()
 		log.Fatal("[ERROR] Provide username, password, DC, and domain!\n")
 	}
-
-	var ldapIP string
-	*ldapServer, ldapIP = goddi.ValidateIPHostname(*ldapServer, *domain)
+	if *ldapIP == "" {
+		*ldapHostname, *ldapIP = goddi.ValidateIPHostname(*ldapHostname, *domain)
+	}
 
 	baseDN := "dc=" + strings.Replace(*domain, ".", ",dc=", -1)
 	username := *user + "@" + *domain
 
 	li := &goddi.LdapInfo{
-		LdapServer:       *ldapServer,
-		LdapIP:           ldapIP,
+		LdapServer:       *ldapHostname,
+		LdapIP:           *ldapIP,
 		LdapPort:         uint16(389),
 		LdapTLSPort:      uint16(636),
 		User:             username,

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 		*mntpoint = *mntpoint + "/"
 	}
 
-	if (len(*ldapHostname) == 0 || len(*ldapIP) == 0) || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
+	if (len(*ldapHostname) == 0 && len(*ldapIP) == 0) || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
 		flag.PrintDefaults()
 		log.Fatal("[ERROR] Provide username, password, DC, and domain!\n")
 	}

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 func main() {
-	ldapHostname := flag.String("dc", "", "Hostname of DC to connect to. ex. -dc=\"dc.test.local\"")
+	ldapServer := flag.String("dc", "", "Hostname of DC to connect to. ex. -dc=\"dc.test.local\"")
 	ldapIP := flag.String("dc-ip", "", "Optional: IP address of DC to connect to (useful if proxyfying without DNS magic)")
 	domain := flag.String("domain", "", "domain ex. -domain=\"test.local\"")
 	user := flag.String("username", "", "username to connect with ex. -username=\"testuser\"")
@@ -44,21 +44,21 @@ func main() {
 		*mntpoint = *mntpoint + "/"
 	}
 
-	if (len(*ldapHostname) == 0 && len(*ldapIP) == 0) || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
+	if (len(*ldapServer) == 0 && len(*ldapIP) == 0) || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
 		flag.PrintDefaults()
 		log.Fatal("[ERROR] Provide username, password, DC, and domain!\n")
 	}
 	if *ldapIP == "" {
-		*ldapHostname, *ldapIP = goddi.ValidateIPHostname(*ldapHostname, *domain)
+		*ldapServer, *ldapIP = goddi.ValidateIPHostname(*ldapServer, *domain)
 	} else {
-		ldapHostname = ldapIP
+		ldapServer = ldapIP
 	}
 
 	baseDN := "dc=" + strings.Replace(*domain, ".", ",dc=", -1)
 	username := *user + "@" + *domain
 
 	li := &goddi.LdapInfo{
-		LdapServer:       *ldapHostname,
+		LdapServer:       *ldapServer,
 		LdapIP:           *ldapIP,
 		LdapPort:         uint16(389),
 		LdapTLSPort:      uint16(636),

--- a/main.go
+++ b/main.go
@@ -44,12 +44,14 @@ func main() {
 		*mntpoint = *mntpoint + "/"
 	}
 
-	if len(*ldapHostname) == 0 || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
+	if (len(*ldapHostname) == 0 || len(*ldapIP) == 0) || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
 		flag.PrintDefaults()
 		log.Fatal("[ERROR] Provide username, password, DC, and domain!\n")
 	}
 	if *ldapIP == "" {
 		*ldapHostname, *ldapIP = goddi.ValidateIPHostname(*ldapHostname, *domain)
+	} else {
+		ldapHostname = ldapIP
 	}
 
 	baseDN := "dc=" + strings.Replace(*domain, ".", ",dc=", -1)

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/swarley7/goddi/ddi"
+	goddi "github.com/swarley7/goddi/ddi"
 )
 
 func main() {
@@ -29,6 +29,7 @@ func main() {
 	startTLS := flag.Bool("startTLS", false, "Use for StartTLS on 389. Default is TLS on 636")
 	unsafe := flag.Bool("unsafe", false, "Use for testing and plaintext connection")
 	forceInsecureTLS := flag.Bool("insecure", false, "Ignore TLS errors (e.g. Self-Signed certificate)")
+	mntpoint := flag.String("mountpoint", "./goddi_mount", "Mount point to use for gpp_password")
 	flag.Parse()
 
 	if len(*ldapServer) == 0 || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
@@ -54,6 +55,7 @@ func main() {
 		Unsafe:           *unsafe,
 		StartTLS:         *startTLS,
 		ForceInsecureTLS: *forceInsecureTLS,
+		MntPoint:         *mntpoint,
 	}
 
 	goddi.Connect(li)
@@ -81,7 +83,7 @@ func main() {
 	goddi.GetFSMORoles(li.Conn, baseDN)
 	goddi.GetSPNs(li.Conn, baseDN)
 	goddi.GetLAPS(li.Conn, baseDN)
-	goddi.GetGPP(li.Conn, li.Domain, li.LdapServer, li.Usergpp, li.Pass)
+	goddi.GetGPP(li.Conn, li.Domain, li.LdapServer, li.Usergpp, li.Pass, li.MntPoint)
 	stop := time.Since(start)
 
 	cwd := goddi.GetCWD()

--- a/main.go
+++ b/main.go
@@ -40,6 +40,9 @@ func main() {
 	if *mntpoint == "" {
 		*mntpoint = dir + "/goddi_mount"
 	}
+	if !strings.HasSuffix(*mntpoint, "/") {
+		*mntpoint = *mntpoint + "/"
+	}
 
 	if len(*ldapServer) == 0 || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
 		flag.PrintDefaults()

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/NetSPI/goddi/ddi"
+	"github.com/swarley7/goddi/ddi"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	pass := flag.String("password", "", "password to connect with ex. -password=\"testpass!\"")
 	startTLS := flag.Bool("startTLS", false, "Use for StartTLS on 389. Default is TLS on 636")
 	unsafe := flag.Bool("unsafe", false, "Use for testing and plaintext connection")
+	forceInsecureTLS := flag.Bool("insecure", false, "Ignore TLS errors (e.g. Self-Signed certificate)")
 	flag.Parse()
 
 	if len(*ldapServer) == 0 || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
@@ -42,16 +43,18 @@ func main() {
 	username := *user + "@" + *domain
 
 	li := &goddi.LdapInfo{
-		LdapServer:  *ldapServer,
-		LdapIP:      ldapIP,
-		LdapPort:    uint16(389),
-		LdapTLSPort: uint16(636),
-		User:        username,
-		Usergpp:     *user,
-		Pass:        *pass,
-		Domain:      *domain,
-		Unsafe:      *unsafe,
-		StartTLS:    *startTLS}
+		LdapServer:       *ldapServer,
+		LdapIP:           ldapIP,
+		LdapPort:         uint16(389),
+		LdapTLSPort:      uint16(636),
+		User:             username,
+		Usergpp:          *user,
+		Pass:             *pass,
+		Domain:           *domain,
+		Unsafe:           *unsafe,
+		StartTLS:         *startTLS,
+		ForceInsecureTLS: *forceInsecureTLS,
+	}
 
 	goddi.Connect(li)
 	defer li.Conn.Close()

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -29,8 +30,16 @@ func main() {
 	startTLS := flag.Bool("startTLS", false, "Use for StartTLS on 389. Default is TLS on 636")
 	unsafe := flag.Bool("unsafe", false, "Use for testing and plaintext connection")
 	forceInsecureTLS := flag.Bool("insecure", false, "Ignore TLS errors (e.g. Self-Signed certificate)")
-	mntpoint := flag.String("mountpoint", "./goddi_mount", "Mount point to use for gpp_password")
+	mntpoint := flag.String("mountpoint", "", "Mount point to use for gpp_password")
 	flag.Parse()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if *mntpoint == "" {
+		*mntpoint = dir + "/goddi_mount"
+	}
 
 	if len(*ldapServer) == 0 || len(*domain) == 0 || len(*user) == 0 || len(*pass) == 0 {
 		flag.PrintDefaults()


### PR DESCRIPTION
Added an optional (secure by default) flag to ignore TLS errors. This is important for situations where the DC is presenting an insecure certificate (self-signed, expired, whatever) and the user wishes to establish the TLS connection anyway (understanding the risks). We have encountered this situation on a few penetration tests.